### PR TITLE
Fix S3 performance regression in Fog::File#empty? method

### DIFF
--- a/lib/carrierwave/storage/fog.rb
+++ b/lib/carrierwave/storage/fog.rb
@@ -317,8 +317,11 @@ module CarrierWave
         # [Boolean] whether the file is non-existent or empty
         #
         def empty?
-          !exists? || size.zero?
+          file_obj = file
+          return true if file_obj.nil?
+          file_obj.content_length.zero?
         end
+        alias_method :blank?, :empty?
 
         ##
         # Check if the file exists on the remote service

--- a/spec/storage/fog_helper.rb
+++ b/spec/storage/fog_helper.rb
@@ -781,6 +781,20 @@ shared_examples "Fog storage" do |fog_credentials|
             expect(@fog_file.empty?).to be true
           end
         end
+
+        context "performance optimization" do
+          it "should not call exists? method when checking empty? on non-existent file" do
+            @fog_file.delete
+            expect(@fog_file).not_to receive(:exists?)
+            expect(@fog_file.empty?).to be true
+          end
+
+          it "should not call size method when checking empty? on existing file" do
+            # The optimization should directly check file.content_length instead of calling size
+            expect(@fog_file).not_to receive(:size)
+            expect(@fog_file.empty?).to be false
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

Fixes the performance regression reported in #2776 where `CarrierWave::Storage::Fog::File#empty?` and `#blank?` methods were causing excessive HEAD requests to S3, resulting in significant performance degradation.

## Problem

### `empty?` method issue

The `empty?` method introduced in v3.1.0 was implemented as:

```ruby
def empty?
  !exists? || size.zero?
end
```

### `blank?` method issue

The issue had two layers:

1. **Proxy layer**: `CarrierWave::Uploader::Proxy#blank?` delegates to the underlying file

```ruby
# In lib/carrierwave/uploader/proxy.rb
def blank?
  file.blank?  # Delegates to Fog::File#blank?
end
```

2. Storage layer: Fog::File was missing a blank? method, causing it to fall back to ActiveSupport's default implementation

ActiveSupport's blank? implementation (fallback)
`respond_to?(:empty?) ? !!empty? : !self`

This created a chain of calls: proxy.blank? → fog_file.blank? → !!fog_file.empty? → multiple S3 HEAD requests.

The performance issue occurred because every call to blank? on an uploader (e.g., user.avatar.blank?) would:
1. Call the proxy's blank? method
2. Delegate to the Fog file's blank? method
3. Fall back to ActiveSupport's implementation
4. Call !!empty? which triggered the inefficient empty? implementation
5. Result in multiple HEAD requests to S3

Solution

Optimized both methods to use a single network call with shared implementation:

```ruby
def empty?
  file_obj = file
  return true if file_obj.nil?
  file_obj.content_length.zero?
end
alias_method :blank?, :empty?
```

This approach:
- ✅ Uses only one HEAD request to S3 (memoized by the file method)
- ✅ Reuses the file object within the method to avoid redundant method calls
- ✅ Provides blank? method that doesn't fall back to ActiveSupport's implementation
- ✅ Preserves consistency with SanitizedFile#empty? semantics

Impact

This change significantly improves performance for applications frequently.
The fix is especially beneficial when using S3 or other cloud storage providers.

Closes #2776